### PR TITLE
RD-107/8 subtype fix/better description

### DIFF
--- a/ModSupport/Tantares/RD107Subtypes.cfg
+++ b/ModSupport/Tantares/RD107Subtypes.cfg
@@ -89,9 +89,9 @@
     		}
 		SUBTYPE
 		{
-      			name = RD-107
+      			name = RD-107A
 	    		title =  Tantares RD-107A "Hagehval" Rocket Engine 
-	    		descriptionSummary = Improvements in overall performance.
+	    		descriptionSummary = A new version for a new era!
 	    		descriptionDetail = <b>Thrust:</b> 255.25 kN Vac / 209.87 kN ASL.\n<b>Isp:</b> 257 s ASL / 314 s Vac.
 			upgradeRequired = RD-107A
 			defaultSubtypePriority = 1

--- a/ModSupport/Tantares/RD108Subtypes.cfg
+++ b/ModSupport/Tantares/RD108Subtypes.cfg
@@ -91,7 +91,7 @@
 		{
       			name = RD-108A
 	    		title =  Tantares RD-108A "Litensegl" Rocket Engine 
-	    		descriptionSummary = Improvements in overall performance.
+	    		descriptionSummary = A new injector for the 21st Century!
 	    		descriptionDetail = <b>Thrust:</b> 230.465 kN Vac / 198.1 kN ASL.\n<b>Isp:</b> 257 s ASL / 314 s Vac.
 			upgradeRequired = RD-107A
 			defaultSubtypePriority = 1


### PR DESCRIPTION
- Two subtypes were named "RD-107"
- The RD-107A description made me vomit internally. I made it better while keeping the previous extreme vagueness.
- The RD-108A description is now actually specific as I have no internal consistency.